### PR TITLE
Introduces settings-toolbar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -25,10 +25,6 @@
   max-width: 34%;
 }
 
-.gs-dataloader-right {
-  margin-left: 135px;
-}
-
 .gs-header {
   display: flex;
   flex-direction: row;
@@ -37,6 +33,10 @@
 
 .gs-header .App-title {
   flex-grow: 1;
+}
+
+.gs-settings {
+  background-color: lightgray;
 }
 
 /* Small devices (landscape phones, less than 768px) */
@@ -53,15 +53,7 @@
     max-width: 95%;
   }
 
-  .gs-dataloader-right {
-    margin-left: auto;
-  }
-
   header > a {
     margin-right: 10px;
   }
-}
-
-.gs-symbolizer-renderer {
-  cursor: pointer;
 }


### PR DESCRIPTION
This introduces a toolbar to the Demo.

![localhost_3000_ 23](https://user-images.githubusercontent.com/1849416/49096338-abf1b600-f26a-11e8-9656-d801143de16b.png)

Existing tools moved to toolbar:
- Language Radios
- LoadStyle Select
- LoadData Select

Newly introduced tools:
- CompactMode switcher
- Symbolizer Radios
