### PR TITLE
Sets SLD as default

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,7 +70,7 @@ class App extends React.Component<AppProps, AppState> {
     this.state = {
       locale: GsLocale.en_US,
       compact: true,
-      ruleRendererType: 'OpenLayers',
+      ruleRendererType: 'SLD',
       style: {
         name: 'Demo Style',
         rules: [{
@@ -200,6 +200,7 @@ class App extends React.Component<AppProps, AppState> {
                   parsers={[
                     SldStyleParser
                   ]}
+                  defaultParser={SldStyleParser}
                   onStyleChange={(style: GsStyle) => {
                     this.setState({style});
                   }}


### PR DESCRIPTION
This sets `ruleRendererType` and `defaultParser` of the `CodeEditor` to "SLD".
So the demo will start with a more common style representation.

This needs https://github.com/terrestris/geostyler/pull/644 to be merged and release first.