### PR TITLE
Package updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,5 @@
     "not dead",
     "not ie <= 11",
     "not op_mini all"
-  ],
-  "resolutions": {
-    "**/@types/react": "16.8.5"
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,30 +1,27 @@
 {
   "name": "geostyler-demo",
-  "version": "0.1.0",
+  "version": "3.1.0",
   "homepage": ".",
   "devDependencies": {},
   "dependencies": {
-    "@types/jest": "24.0.0",
-    "@types/node": "10.12.21",
-    "@types/react-dom": "16.0.11",
-    "@types/react": "16.7.18",
-    "antd": "3.12.3",
+    "@types/react-dom": "16.8.2",
+    "@types/react": "16.8.5",
+    "antd": "3.13.6",
     "geostyler-geojson-parser": "0.4.6",
     "geostyler-sld-parser": "0.18.0",
     "geostyler-style": "0.14.3",
     "geostyler-wfs-parser": "0.7.3",
-    "geostyler": "1.0.1",
-    "moment": "2.23.0",
+    "geostyler": "3.1.0",
+    "moment": "2.24.0",
     "ol": "5.3.1",
     "react-dom": "16.8.3",
-    "react-scripts": "2.1.3",
+    "react-scripts": "2.1.5",
     "react": "16.8.3",
-    "typescript": "3.2.2"
+    "typescript": "3.3.3"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --transformIgnorePatterns \"<rootDir>/node_modules/(?!ol|antd)\"",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
@@ -35,5 +32,8 @@
     "not dead",
     "not ie <= 11",
     "not op_mini all"
-  ]
+  ],
+  "resolutions": {
+    "**/@types/react": "16.8.5"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts --max-old-space-size=4096 build",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geostyler-demo",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "homepage": ".",
   "devDependencies": {},
   "dependencies": {
@@ -11,7 +11,7 @@
     "geostyler-sld-parser": "0.18.0",
     "geostyler-style": "0.14.3",
     "geostyler-wfs-parser": "0.7.3",
-    "geostyler": "3.1.0",
+    "geostyler": "3.1.1",
     "moment": "2.24.0",
     "ol": "5.3.1",
     "react-dom": "16.8.3",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
-
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
-  ReactDOM.unmountComponentAtNode(div);
-});


### PR DESCRIPTION
This updates lots of packages.

It also removes the test `@types/jest` and `@types/node`.

Version is now in sync with the 'geostyler' package.

closes #86 
closes #85
closes #84 
closes #82 
closes #81
closes #80 
closes #72 
closes #71 
closes #70 
closes #71

@terrestris/devs please review