### PR TITLE
Replace deprecated localProvider with ConfigProvider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
 import {
+  ConfigProvider,
   Form,
-  LocaleProvider,
   Radio,
   Switch,
   Button
@@ -203,7 +203,7 @@ class App extends React.Component<AppProps, AppState> {
       ruleRendererType
     } = this.state;
     return (
-      <LocaleProvider locale={locale}>
+      <ConfigProvider locale={locale}>
         <div className="app">
           <header className="gs-header">
             <span className="logo-title">
@@ -307,7 +307,7 @@ class App extends React.Component<AppProps, AppState> {
             width="50%"
           />
         </div>
-      </LocaleProvider>
+      </ConfigProvider>
     );
   }
 }

--- a/src/ExamplesDialog.tsx
+++ b/src/ExamplesDialog.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import {
-  LocaleProvider,
+  ConfigProvider,
   Modal
 } from 'antd';
 import { Locale } from 'antd/lib/locale-provider/index';
@@ -151,7 +151,7 @@ class ExamplesDialog extends React.Component<ExamplesDialogProps, ExampleDialogS
     });
 
     return (
-      <LocaleProvider locale={locale}>
+      <ConfigProvider locale={locale}>
           <Modal
             className="examples-dialog"
             {...passThroughProps}
@@ -162,7 +162,7 @@ class ExamplesDialog extends React.Component<ExamplesDialogProps, ExampleDialogS
           >
             {cards}
           </Modal>
-      </LocaleProvider>
+      </ConfigProvider>
     );
   }
 }


### PR DESCRIPTION
antd's `localeProvider` component is deprecated and should be replaced with `configProvider`. This was done in this PR.

- [ConfigProvider docs](https://ant.design/components/config-provider/)
- [deprecated localeProvider docs](https://ant.design/components/locale-provider/)